### PR TITLE
Fix profiling timing and add logger tests

### DIFF
--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -1,0 +1,16 @@
+const Logger = require('../src/logger');
+
+describe('Logger.profile', () => {
+  test('returns valid duration and logs debug message', () => {
+    const logger = new Logger();
+    const spy = jest.spyOn(logger, 'debug').mockImplementation(() => {});
+    const profiler = logger.profile('test');
+    const duration = profiler.end();
+    expect(typeof duration).toBe('number');
+    expect(Number.isNaN(duration)).toBe(false);
+    expect(spy).toHaveBeenCalledWith(
+      'Profile: test',
+      expect.objectContaining({ duration: expect.stringMatching(/ms$/) })
+    );
+  });
+});

--- a/src/logger.js
+++ b/src/logger.js
@@ -275,10 +275,11 @@ class Logger {
 
     // Performance profiling
     profile(name) {
+        const start = Date.now();
         return {
-            start: Date.now(),
+            start,
             end: () => {
-                const duration = Date.now() - this.start;
+                const duration = Date.now() - start;
                 this.debug(`Profile: ${name}`, { duration: `${duration}ms` });
                 return duration;
             }


### PR DESCRIPTION
## Summary
- fix `Logger.profile` to compute duration using a captured start time
- add Jest tests for `Logger.profile` to ensure profiling works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895f30ad8e8832e96edc340de449c1d